### PR TITLE
Refactored CLI and added back a refactored version of Michael's Duet3D timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can find the `arcgcode` framework developer documentation in [here](./docs/A
 - [Getting Started](#getting-started)
 - [Contributor's Getting Started](#contributors-getting-started)
 - [Debugging with the CLI](#debugging-with-the-cli)
+- [Timing with the CLI](#timing-with-the-cli)
 
 ## Getting Started
 
@@ -57,7 +58,16 @@ make -f Makefile.unix debug
 You can also debug the G-Code parsing with default settings with the CLI:
 
 ```bash
-python3 cli.py -i tests/gcodes/inputs/calibration_cube.gcode -o arc1_gcodes -v
+python cli.py gcode -i tests/gcodes/inputs/calibration_cube.gcode \
+    -o arc1_gcodes -v
 ```
 
 This is much faster than slicing and then downloading the parsed G-Code in Cura to view your results.
+
+## Timing with the CLI
+
+To time your printing run with nice exporting, call:
+
+```bash
+python cli.py time
+```

--- a/cli.py
+++ b/cli.py
@@ -1,60 +1,103 @@
-"""
-Arc One GCode Parser Proof Of Concept
-Parses GCode files based on the instructions in ./examples/README.md so that
-our printer can print the GCode.
-"""
+import typer
+from arcgcode.duet.timer import DuetTimer, ARC_ONE_DUET_URL
+from typing_extensions import Annotated
 
-if __name__ == "__main__":
-    import argparse
+
+app = typer.Typer()
+
+
+@app.command()
+def time():
+    duet_timer = DuetTimer(ARC_ONE_DUET_URL)
+    duet_timer.run()
+
+
+# This is jank, but it makes things more readable
+args_help = {
+    "-i": "The path to an input directory of GCodes or the path to a G-Code " +
+    "file to transform.",
+    "-o": "The path to the output directory where the parsed GCodes will be " +
+    "generated to",
+    "-v": "Toggles on debug logging.",
+}
+
+# Type aliases for the gcode command.
+InputDirOrFilePathCliArg = Annotated[str, typer.Option("--input", "-i",
+                                                       help=args_help["-i"])]
+OutputDirCliArg = Annotated[str, typer.Option("--output_dir", "-o",
+                                              help=args_help["-o"])]
+VerboseCliArg = Annotated[bool, typer.Option("--verbose", "-v",
+                                             help=args_help["-v"])]
+
+
+@app.command()
+def gcode(input_dir_or_file_path: InputDirOrFilePathCliArg,
+          output_dir: OutputDirCliArg,
+          verbose: VerboseCliArg = True):
+    """
+    Processes the G-Code to a WAAM compatible format.
+
+    This is a good backup just in-case the Cura post-processing script is not
+    completely functional.
+
+    You can generate a G-Code using Cura. Then call this command:
+
+    python cli.py gcode -i PATH_TO_CURA_GCODE -o output_gcodes -v
+
+    Make sure to replace PATH_TO_CURA_GCODE with the path to your generated
+    Cura G-Code. This will generate the WAAM compatible G-Code inside of the
+    output_gcodes directory relative to the current directory.
+
+    An example that works as of 11/19 is:
+
+    python cli.py gcode -i tests/gcodes/inputs/calibration_cube.gcode \
+        -o arc1_gcodes -v
+
+    This will generate a file called edited_calibration_cube.gcode in the
+    arc1_gcodes directory. This new G-Code file should be compatible with the
+    Arc One WAAM machine.
+    """
     import logging
     import os
     import sys
     from glob import glob
     from pathlib import Path
-    from arcgcode.v1 import CuraPostProcessor, CuraMicerSettings  
+    from arcgcode.v1 import CuraPostProcessor, CuraMicerSettings
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input", help="Input directory of GCodes or" +
-                        "G-Code file to transform.",
-                        type=str)
-    parser.add_argument("-o", "--output_dir", help="Output directory where " +
-                        "the parsed GCodes will go.", type=str)
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Debug logging.")
-    args = parser.parse_args()
-
-    if (args.verbose):
+    if (verbose):
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    logging.debug("args: %s", args)
+    logging.debug("args: Input Path: %s, Output Path: %s, Verbose: %r",
+                  input_dir_or_file_path, output_dir, verbose)
 
-    if not os.path.isdir(args.input) and not os.path.isfile(args.input):
-        logging.error(
-            "specified input dir '%s' is not a directory or file", args.input)
+    if (not os.path.isdir(input_dir_or_file_path) and
+       not os.path.isfile(input_dir_or_file_path)):
+        logging.error("specified input dir '%s' is not a directory or file",
+                      input_dir_or_file_path)
         sys.exit()
 
     # Allows you to specify a non-existing output directory if necessary
-    if not os.path.isdir(args.output_dir):
-        output_dir_path = os.path.abspath(args.output_dir)
+    if not os.path.isdir(output_dir):
+        output_dir_path = os.path.abspath(output_dir)
         logging.info("Creating output directory %s...", output_dir_path)
-        os.makedirs(args.output_dir)
+        os.makedirs(output_dir)
 
-    if os.path.isfile(args.input):
-        gcode_files = [args.input]
+    if os.path.isfile(input_dir_or_file_path):
+        gcode_files = [input_dir_or_file_path]
     else:
-        input_dir = os.path.abspath(args.input)
+        input_dir = os.path.abspath(input_dir_or_file_path)
         gcode_files = glob(os.path.join(input_dir, "*.gcode"))
 
     if len(gcode_files) == 0:
         logging.error(
             "Found 0 GCode files in the specified input directory %s.\n" +
             "Please double check that it's specified correctly with -v",
-            args.input)
+            input_dir_or_file_path)
         sys.exit()
 
-    output_dir = os.path.abspath(args.output_dir)
+    output_dir = os.path.abspath(output_dir)
 
     logging.info("Found %d gcode files.\nConverting to WAAM version...", len(
         gcode_files))
@@ -72,3 +115,8 @@ if __name__ == "__main__":
                 f.write("".join(new_gcode))
 
     logging.info("Done! All created files are in %s", output_dir)
+    return
+
+
+if __name__ == "__main__":
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-duetwebapi
+duetwebapi==1.2.2
 PyQt6
 pyqtgraph
 PyOpenGL
 pyyaml
-numpy
+numpy==1.25.1
+typer==0.9.0

--- a/src/arcgcode/duet/timer.py
+++ b/src/arcgcode/duet/timer.py
@@ -1,0 +1,39 @@
+from duetwebapi import DuetWebAPI
+import time
+import atexit
+# from Consts import URL
+
+ARC_ONE_DUET_URL = "http://169.254.1.1"
+
+
+class DuetTimer(object):
+    """Times different actions of each print and layer and exports the data to
+    CSV.
+
+    Useful documentation:
+    https://reprap.org/wiki/RepRap_Firmware_Status_responses
+    """
+    def __init__(self, url: str) -> None:
+        self.duet = DuetWebAPI(url)
+        self.duet.connect()
+        print("Connected")
+    
+    def run(self):
+        start_time = 0
+        started_flag = False
+        atexit.register(self.duet.disconnect)
+        while True:
+            try:
+                if (self.duet.get_model("state.status") == "processing" and
+                   not started_flag):
+                    print("Started Timer")
+                    start_time = time.time()
+                    started_flag = True
+                if (self.duet.get_model("state.status") == "idle" and
+                   started_flag):
+                    end_time = time.time()
+                    print(f"Print finished in{end_time-start_time} seconds")
+                    start_time = 0
+                    started_flag = False
+            except ValueError:
+                pass


### PR DESCRIPTION
CLI now uses `typer` so you can have more professional subcommands, help descriptions, doc strings, etc..

Created `DuetTimer` to provide some boilerplate for our upcoming layer-by-layer timing print data exporter.
* The current version is basically the same thing as @InvincibleRMC 's `timer.py` in one of the earliest iterations of this repository.